### PR TITLE
Fix: Add shell environment prerequisites warning to Claude Code docs

### DIFF
--- a/docs/code-pasting/claude-code/index.md
+++ b/docs/code-pasting/claude-code/index.md
@@ -6,6 +6,9 @@ Documentation for Claude Code, an AI-powered development tool integrated into th
 
 Claude Code provides AI-assisted development capabilities for code generation, analysis, and problem-solving. This setup uses AWS Bedrock for model inference, enabling local-first Claude Code execution.
 
+!!! warning "Prerequisites: Shell Environment Required"
+    Claude Code depends on a properly configured shell environment with git and GitHub working correctly. Before installing Claude Code, ensure your shell is set up properly. If you need help with shell configuration, SSH keys, or Git setup, see our **[Shell Setup Guide](../../shell/)** for automated configuration.
+
 ## Setup
 
 ### 1. Configure AWS Credentials and Region


### PR DESCRIPTION
## Automated Fix by Claude Code

This PR automatically addresses issue #11.

**Changes**:
- Added a warning admonition box before the Setup section in `docs/code-pasting/claude-code/index.md`
- Warning informs users that Claude Code requires a properly configured shell environment
- Includes link to the Shell Setup Guide for automated configuration

**Issue**: Test: Re-test shell docs pointer with permission fix

This was generated by the GitHub Actions auto-fix workflow using Claude Code with AWS Bedrock.

Fixes #11